### PR TITLE
Change Cursor#skip() in order to make it work.

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -98,11 +98,11 @@ Cursor.prototype.setReadPreference = function(pref) {
 };
 /**
  * Sets the skip parameter of this cursor to the given value.
- * @param pref
+ * @param {number} skipped Amount of documents skipped
  * @returns {Cursor}
  */
-Cursor.prototype.skip = function(pref) {
-    this._cursor.setReadPreference(pref);
+Cursor.prototype.skip = function(skipped) {
+    this._cursor.skip(skipped);
     return this;
 };
 /**


### PR DESCRIPTION
`Cursor#skip()` felt like it was copied from `Cursor#setReadPreference()`. It prevented me to use this function correctly. I made a patch.
